### PR TITLE
Update graphql patch to work with raygun-node-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun-node-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun-node-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/src/index.js",
   "dependencies": {

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -52,17 +52,20 @@ export type Request = {
   moduleName: string;
 };
 
+export type GraphQL = { asyncId: number; query: string };
+
 export const effects = new TypedEventEmitter<{
   query: Query;
   request: Request;
+  graphql: GraphQL;
 }>();
 
 export function recordQuery(
   moduleName: string,
   startTime: BI.PortableBigInt,
   asyncId: number,
-): Query['events'] {
-  const events = new TypedEventEmitter();
+): QueryEvents {
+  const events: QueryEvents = new TypedEventEmitter();
 
   effects.emit('query', {
     startTime,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { effects, Request, Query, RequestEvents, QueryEvents } from './effects';
+export { effects, Request, Query, RequestEvents, QueryEvents, GraphQL } from './effects';
 export { RequestInformation, QueryInformation } from './types';
 export * as modulePatches from './module_patches';
 export * as BI from './bigint';

--- a/src/module_patches.ts
+++ b/src/module_patches.ts
@@ -145,6 +145,7 @@ export function loadAll() {
   const patches = [
     'http_outgoing',
     'elasticsearch',
+    'graphql',
     'memcached',
     'mongodb3',
     'mongodb4',

--- a/src/module_patches/graphql.ts
+++ b/src/module_patches/graphql.ts
@@ -1,35 +1,41 @@
-import path from 'path';
+import { executionAsyncId } from 'async_hooks';
 import type { IncomingMessage } from 'http';
+import path from 'path';
 
+import { effects } from '../effects';
 import { patchModules } from '../module_patches';
 
-function recordIncomingGraphQLQuery(query: string) {}
+function recordIncomingGraphQLQuery(query: string) {
+  effects.emit('graphql', { query, asyncId: executionAsyncId() });
+}
 
-patchModules([path.join('graphql')], (exports) => {
-  const originalGraphql = exports.graphql;
+export function load() {
+  patchModules([path.join('graphql')], (exports) => {
+    const originalGraphql = exports.graphql;
 
-  function graphql<This, Schema, OtherArgs>(
-    this: This,
-    schema: Schema,
-    query: string,
-    ...args: OtherArgs[]
-  ) {
-    recordIncomingGraphQLQuery(query);
+    function graphql<This, Schema, OtherArgs>(
+      this: This,
+      schema: Schema,
+      query: string,
+      ...args: OtherArgs[]
+    ) {
+      recordIncomingGraphQLQuery(query);
 
-    return originalGraphql.call(this, schema, query, ...args);
-  }
+      return originalGraphql.call(this, schema, query, ...args);
+    }
 
-  const originalExecute = exports.execute;
+    const originalExecute = exports.execute;
 
-  function execute<This, Args extends { document: Document }, Document, OtherArgs>(
-    this: This,
-    args: Args,
-    ...otherArgs: OtherArgs[]
-  ) {
-    recordIncomingGraphQLQuery(exports.print(args.document));
+    function execute<This, Args extends { document: Document }, Document, OtherArgs>(
+      this: This,
+      args: Args,
+      ...otherArgs: OtherArgs[]
+    ) {
+      recordIncomingGraphQLQuery(exports.print(args.document));
 
-    return originalExecute.call(this, args, ...otherArgs);
-  }
+      return originalExecute.call(this, args, ...otherArgs);
+    }
 
-  return { ...exports, graphql, execute };
-});
+    return { ...exports, graphql, execute };
+  });
+}

--- a/tests/graphql_test.ts
+++ b/tests/graphql_test.ts
@@ -1,5 +1,7 @@
 require('../src/module_patches').loadAll();
 
+import { effects } from '../src/effects';
+
 import assert from 'assert';
 import express from 'express';
 import superagent from 'superagent';
@@ -42,17 +44,21 @@ async function startApolloServer(port: number): Promise<{ graphqlPath: string; s
 }
 
 describe('apollo support', () => {
-  it('keeps recording the trace until all associated http activity completes', async function () {
-    const port = 10952;
-    const { graphqlPath, stop } = await startApolloServer(port);
+  it('keeps recording the trace until all associated http activity completes', function (done) {
+    (async function () {
+      const port = 10952;
+      const { graphqlPath, stop } = await startApolloServer(port);
 
-    await superagent
-      .post(`http://localhost:${port}${graphqlPath}/`)
-      .set('Content-Type', 'application/json')
-      .send({ operationName: null, query: '{ hello }', variables: null })
-      .catch((e) => console.log(e));
+      effects.once('graphql', (query) => {
+        assert.strictEqual(query.query, '{\n  hello\n}');
+        done();
+      });
 
-    // TODO - assert that we got a graphql query
-    // assert.strictEqual(methodInfo.methodName, 'GraphQL: { hello }');
+      superagent
+        .post(`http://localhost:${port}${graphqlPath}/`)
+        .set('Content-Type', 'application/json')
+        .send({ operationName: null, query: '{ hello }', variables: null })
+        .catch((e) => done(e));
+    })();
   }).timeout(10000);
 });


### PR DESCRIPTION
Forgot to adapt this patch as part of the recent merge. This is
everything required to get the APM tests passing, as well as a
package.json version bump so that we can release these new changes when
desired.